### PR TITLE
This PR fixes an issue and non optimal connection cleanup logic and a startup bug. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "colors": "^1.1.2",
     "inquirer": "^0.12.0",
     "mkdirp": "^0.5.1",
-    "mongoose": "^4.4.6",
     "yargs": "^4.8.1"
+  },
+  "peerDependencies": {
+    "mongoose": "^4.4.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,9 +36,7 @@
     "colors": "^1.1.2",
     "inquirer": "^0.12.0",
     "mkdirp": "^0.5.1",
+    "mongoose": "^4.4.6",
     "yargs": "^4.8.1"
-  },
-  "peerDependencies": {
-    "mongoose": "^4.4.6"
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -120,6 +120,19 @@ let migrator = new Migrator({
   cli: true
 });
 
+process.on('SIGINT', () => {
+  migrator.close().then(() => {
+    process.exit(0);
+  });
+});
+
+process.on('exit', () => {
+  // NOTE: This is probably useless since close is async and 'exit' does not wait for the code to finish before
+  // exiting ther process, so it's a race condition between exiting and closing.
+  migrator.close();
+});
+
+
 let promise;
 switch(command) {
   case 'create':

--- a/src/db.js
+++ b/src/db.js
@@ -34,9 +34,6 @@ export default function ( collection = 'migrations', dbConnection ) {
     console.error(`MongoDB Connection Error: ${err}`);
   });
 
-  process.on('SIGINT', () => { dbConnection.close(); });
-  process.on('exit', () => { dbConnection.close(); });
-
   return dbConnection.model( collection, MigrationSchema );
 }
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -257,11 +257,10 @@ export default class Migrator {
           migrationName = migrationToImport.slice(timestampSeparatorIndex + 1, migrationToImport.lastIndexOf('.'));
 
         this.log(`Adding migration ${filePath} into database from file system. State is ` + `DOWN`.red);
-        const createdMigration = MigrationModel.create({
+        return MigrationModel.create({
           name: migrationName,
           createdAt: timestamp
-        });
-        return createdMigration;
+        }).then(createdMigration => createdMigration.toJSON());
       });
     } catch (error) {
       this.log(`Could not synchronise migrations in the migrations folder up to the database.`.red);

--- a/src/lib.js
+++ b/src/lib.js
@@ -228,7 +228,7 @@ export default class Migrator {
       const migrationsInFolder = _.filter(filesInMigrationFolder, file => /\d{13,}\-.+.js$/.test(file))
         .map(filename => {
           const fileCreatedAt = parseInt(filename.split('-')[0]);
-          const existsInDatabase = !!_.find(migrationsInDatabase, {createdAt: new Date(fileCreatedAt)});
+          const existsInDatabase = migrationsInDatabase.some(m => filename == `${m.createdAt.getTime()}-${m.name}.js`);
           return {createdAt: fileCreatedAt, filename, existsInDatabase};
         });
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -257,7 +257,7 @@ export default class Migrator {
           name: migrationName,
           createdAt: timestamp
         });
-        return createdMigration.toJSON();
+        return createdMigration;
       });
     } catch (error) {
       this.log(`Could not synchronise migrations in the migrations folder up to the database.`.red);

--- a/src/lib.js
+++ b/src/lib.js
@@ -228,7 +228,7 @@ export default class Migrator {
       const migrationsInFolder = _.filter(filesInMigrationFolder, file => /\d{13,}\-.+.js$/.test(file))
         .map(filename => {
           const fileCreatedAt = parseInt(filename.split('-')[0]);
-          const existsInDatabase = migrationsInDatabase.some(m => filename == `${m.createdAt.getTime()}-${m.name}.js`);
+          const existsInDatabase = migrationsInDatabase.some(m => filename == m.filename);
           return {createdAt: fileCreatedAt, filename, existsInDatabase};
         });
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -77,6 +77,10 @@ export default class Migrator {
     }
   }
 
+  close() {
+    return this.connection ? this.connection.close() : null;
+  }
+
   async create(migrationName) {
     try {
       const existingMigration = await MigrationModel.findOne({ name: migrationName });


### PR DESCRIPTION
1. First, there was a bug where you were trying to return toJSON on a Promise to create a migration. This caused a fatal exception whenever a migration script not in the DB was added. I am using Migrator class programmatically in the following manner: 
```
const migrator = new migrateMongoose({
        migrationsPath:  path.join(__dirname, '/migrations/'),
        dbConnectionUri: process.env.MONGO_URL,
        es6Templates:    false,
        collectionName:  '_migrations',
        autosync:        true
      });

      return migrator.run('up')
      .then(m => m.map(n => n.name))
      .then(result => migrator.close().then(() => result))
      .catch(e => {
        if(e.message == 'There are no migrations to run') {
          return []; // NOTE: this is shitty, but the library throws an exception when there are no migrations to run instead telling us in a nice way :-/
        }
        throw e;
      });
```
The exception I saw was 
```
TypeError: createdMigration.toJSON is not a function
    at /
node_modules/migrate-mongoose/dist/lib.js:534:55
    at tryCatcher (/
node_modules/bluebird/js/release/util.js:16:23)
    at MappingPromiseArray._promiseFulfilled (/
node_modules/bluebird/js/release/map.js:61:38)
    at MappingPromiseArray.PromiseArray._iterate (/
node_modules/bluebird/js/release/promise_array.js:113:31)
    at MappingPromiseArray.init (/
node_modules/bluebird/js/release/promise_array.js:77:10)
    at MappingPromiseArray._asyncInit (/
node_modules/bluebird/js/release/map.js:30:10)
    at Async._drainQueue (/
node_modules/bluebird/js/release/async.js:138:12)
    at Async._drainQueues (/
node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues [as _onImmediate] (node_modules/bluebird/js/release/async.js:17:14)
    at tryOnImmediate (timers.js:543:15)
    at processImmediate [as _immediateCallback] (timers.js:523:5)
```


2. A process that uses the Migrator class, could not be stopped with Ctrl-C. This is due to the fact that SIGINT was being trapped and process.exit() was not being called. If you trap SIGINT, it is your responsibility to call process.exit(). Since process.exit() must be called in the SIGINT handler, the db.js class is not (probably wasn't before either) a proper place to install the handlers (i.e. if I use Migrations class, I don't want it exiting my process for me, or interfering with other SIGINT handlers I may be using). Additionally, since the Migrations class is the thing that creates the connection, it should be the place that has a method to cleaning it up. Having a `close()` method on the Migrator also allows programatic cleanup as soon as Migrator is not being used anymore (i.e. I don't need to wait until process exit to clean up). The cleanup that happens on SIGINT should be `cli.js`, there the Migrator is created, and there it should be closed. One final note is that closing the mongoose connection is an async operation, so trying to close it in it`process.on('exit')` will not likely do what it is supposed to, and/or there will be a race condition. You should only do synchronous code in the exit handler. I kept handler anyway, but added a note incase you want to do further testing to decide if you want to remove it since it may or may not work. 