### PR TITLE
Fix reversed args to migrator.run() in programmatic usage README

### DIFF
--- a/examples/programmatic-usage/README.md
+++ b/examples/programmatic-usage/README.md
@@ -30,10 +30,10 @@ migrator.create(migrationName).then(()=> {
 });
 
 // Migrate Up
-promise = migrator.run(migrationName, 'up');
+promise = migrator.run('up', migrationName);
 
 // Migrate Down
-promise = migrator.run(migrationName, 'down');
+promise = migrator.run('down', migrationName);
 
 // List Migrations
 /*


### PR DESCRIPTION
Proper order of migrator.run() arguments is migrator.run('up', migrationName). Tested and working on latest master.

examples/programmatic-usage/README.md incorrectly shows migrator.run(migrationName, 'up').

Fixed it to reflect proper usage.
