### PR TITLE
Fix: `migrate down` without a migration name rollbacks only the last migration; Fix #26

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -134,9 +134,13 @@ export default class Migrator {
   async run(direction = 'up', migrationName) {
     await this.sync();
 
+    if (direction !== 'up' && direction !== 'down') {
+      throw new Error(`The '${direction}' is not supported, use the 'up' or 'down' direction`);
+    }
+
     const untilMigration = migrationName ?
       await MigrationModel.findOne({name: migrationName}) :
-      await MigrationModel.findOne().sort({createdAt: -1});
+      await MigrationModel.findOne().sort({createdAt: directions == 'up' ? -1 : 1});
 
     if (!untilMigration) {
       if (migrationName) throw new ReferenceError("Could not find that migration in the database");

--- a/src/lib.js
+++ b/src/lib.js
@@ -140,7 +140,7 @@ export default class Migrator {
 
     const untilMigration = migrationName ?
       await MigrationModel.findOne({name: migrationName}) :
-      await MigrationModel.findOne().sort({createdAt: directions == 'up' ? -1 : 1});
+      await MigrationModel.findOne().sort({createdAt: direction === 'up' ? -1 : 1});
 
     if (!untilMigration) {
       if (migrationName) throw new ReferenceError("Could not find that migration in the database");


### PR DESCRIPTION
For the 'down' direction we have to sort with `createdAt: 1` options. Because we need the first migration, instead the last one for the 'up' direction.