### PR TITLE
Pass additional run args onto migration functions

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -112,7 +112,7 @@ class Migrator {
    * @param migrationName
    * @param direction
    */
-  async run(direction = 'up', migrationName) {
+  async run(direction = 'up', migrationName, ...args) {
     await this.sync();
 
     if (direction !== 'up' && direction !== 'down') {
@@ -173,7 +173,8 @@ class Migrator {
             function callback(err) {
               if (err) return reject(err);
               resolve();
-            }
+            },
+            ...args
           );
 
           if (callPromise && typeof callPromise.then === 'function') {


### PR DESCRIPTION
I had a use case, where I required additional arguments that were available when calling Migrator#run programmatically inside the migrating (up/down) functions.
I think this is a valid requirement for quite a few cases, therefore this might fit into the main repo.