### PR TITLE
moved global MigrationModel to class

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -63,6 +63,7 @@ class Migrator {
    */
   setMongooseConnection(connection) {
     this.migrationModel = MigrationModelFactory(this.collection, connection)
+    return this
   }
 
   /**

--- a/src/lib.js
+++ b/src/lib.js
@@ -9,7 +9,6 @@ const mongoose = require('mongoose');
 const Promise = require('bluebird');
 
 const MigrationModelFactory = require('./db');
-let MigrationModel;
 
 Promise.config({
   warnings: false
@@ -49,7 +48,7 @@ class Migrator {
     this.collection = collectionName;
     this.autosync = autosync;
     this.cli = cli;
-    MigrationModel = MigrationModelFactory(collectionName, this.connection);
+    this.migrationModel = MigrationModelFactory(collectionName, this.connection);
   }
 
   log(logString, force = false) {
@@ -63,8 +62,7 @@ class Migrator {
    * @param {mongoose.connection} connection - Mongoose connection
    */
   setMongooseConnection(connection) {
-    MigrationModel = MigrationModelFactory(this.collection, connection)
-    return this
+    this.migrationModel = MigrationModelFactory(this.collection, connection)
   }
 
   /**
@@ -82,7 +80,7 @@ class Migrator {
    */
   async create(migrationName) {
     try {
-      const existingMigration = await MigrationModel.findOne({ name: migrationName });
+      const existingMigration = await this.migrationModel.findOne({ name: migrationName });
       if (!!existingMigration) {
         throw new Error(`There is already a migration with name '${migrationName}' in the database`.red);
       }
@@ -94,7 +92,7 @@ class Migrator {
       fs.writeFileSync(path.join(this.migrationPath, newMigrationFile), this.template);
       // create instance in db
       await this.connection;
-      const migrationCreated = await MigrationModel.create({
+      const migrationCreated = await this.migrationModel.create({
         name: migrationName,
         createdAt: now
       });
@@ -120,8 +118,8 @@ class Migrator {
     }
 
     const untilMigration = migrationName ?
-      await MigrationModel.findOne({ name: migrationName }) :
-      await MigrationModel.findOne().sort({ createdAt: direction === 'up' ? -1 : 1 });
+      await this.migrationModel.findOne({ name: migrationName }) :
+      await this.migrationModel.findOne().sort({ createdAt: direction === 'up' ? -1 : 1 });
 
     if (!untilMigration) {
       if (migrationName) throw new ReferenceError("Could not find that migration in the database");
@@ -142,7 +140,7 @@ class Migrator {
 
 
     const sortDirection = direction == 'up' ? 1 : -1;
-    const migrationsToRun = await MigrationModel.find(query)
+    const migrationsToRun = await this.migrationModel.find(query)
       .sort({ createdAt: sortDirection });
 
     if (!migrationsToRun.length) {
@@ -183,7 +181,7 @@ class Migrator {
 
         this.log(`${direction.toUpperCase()}:   `[direction == 'up' ? 'green' : 'red'] + ` ${migration.filename} `);
 
-        await MigrationModel.where({ name: migration.name }).updateMany({ $set: { state: direction } });
+        await this.migrationModel.where({ name: migration.name }).updateMany({ $set: { state: direction } });
         migrationsRan.push(migration.toJSON());
         numMigrationsRan++;
       } catch (err) {
@@ -198,17 +196,15 @@ class Migrator {
   }
 
   /**
-   * sync file system -> database
-   * 
-   * Imports any migrations that are on the file system but
-   * missing in the database into the database
-   * 
+   * Looks at the file system migrations and imports any migrations that are
+   * on the file system but missing in the database into the database
+   *
    * This functionality is opposite of prune()
    */
   async sync() {
     try {
       const filesInMigrationFolder = fs.readdirSync(this.migrationPath);
-      const migrationsInDatabase = await MigrationModel.find({});
+      const migrationsInDatabase = await this.migrationModel.find({});
       // Go over migrations in folder and delete any files not in DB
       const migrationsInFolder = _.filter(filesInMigrationFolder, file => /\d{13,}\-.+.js$/.test(file))
         .map(filename => {
@@ -242,7 +238,7 @@ class Migrator {
           migrationName = migrationToImport.slice(timestampSeparatorIndex + 1, migrationToImport.lastIndexOf('.'));
 
         this.log(`Adding migration ${filePath} into database from file system. State is ` + `DOWN`.red);
-        const createdMigration = await MigrationModel.create({
+        const createdMigration = await this.migrationModel.create({
           name: migrationName,
           createdAt: timestamp
         });
@@ -255,15 +251,13 @@ class Migrator {
   }
 
   /**
-   * sync migration database -> file system
-   * 
    * Opposite of sync().
    * Removes files in migration directory which don't exist in database.
    */
   async prune() {
     try {
       const filesInMigrationFolder = fs.readdirSync(this.migrationPath);
-      const migrationsInDatabase = await MigrationModel.find({});
+      const migrationsInDatabase = await this.migrationModel.find({});
       // Go over migrations in folder and delete any files not in DB
       const migrationsInFolder = _.filter(filesInMigrationFolder, file => /\d{13,}\-.+.js/.test(file))
         .map(filename => {
@@ -294,14 +288,14 @@ class Migrator {
         migrationsToDelete = answers.migrationsToDelete;
       }
 
-      const migrationsToDeleteDocs = await MigrationModel
+      const migrationsToDeleteDocs = await this.migrationModel
         .find({
           name: { $in: migrationsToDelete }
         }).lean();
 
       if (migrationsToDelete.length) {
         this.log(`Removing migration(s) `, `${migrationsToDelete.join(', ')}`.cyan, ` from database`);
-        await MigrationModel.deleteMany({
+        await this.migrationModel.deleteMany({
           name: { $in: migrationsToDelete }
         });
       }
@@ -324,7 +318,7 @@ class Migrator {
    */
   async list() {
     await this.sync();
-    const migrations = await MigrationModel.find().sort({ createdAt: 1 });
+    const migrations = await this.migrationModel.find().sort({ createdAt: 1 });
     if (!migrations.length) this.log('There are no migrations to list.'.yellow);
     return migrations.map((m) => {
       this.log(
@@ -346,4 +340,3 @@ function fileRequired(error) {
 
 
 module.exports = Migrator;
-


### PR DESCRIPTION
global MigrationModel is moved to class.
why? if the class is programmatically instantiated multiple times (multiple folders & collections), the last loaded model was overriding all.